### PR TITLE
Fix tad postgres secret

### DIFF
--- a/apps/tad/overlays/production/secret-postgres.yaml
+++ b/apps/tad/overlays/production/secret-postgres.yaml
@@ -4,8 +4,8 @@ metadata:
     name: sec-postgres
 type: Opaque
 stringData:
-    password: ENC[AES256_GCM,data:cujyi9aWrCEykCdpqfGnKA==,iv:zea+l0qr5m5SgQ+ulGJz1fdAt2Lv8c+U5T/Q38FpOcQ=,tag:lCKL//CjF2T99rA/4PRNjg==,type:str]
-    username: ENC[AES256_GCM,data:nB7r,iv:hUpfmiWhydooNK9GDnTPqS3fKYZY8iVBl6w2KltTVzg=,tag:/zadWOLrzUt0rp8z/uaJ4w==,type:str]
+    password: ENC[AES256_GCM,data:+BJUkaEc6/UWdj7oY0kQ0Q==,iv:Z20jv/lp7uyH5vxcC5T3jpZ/DpdDGsq9LUU6Ap+AzSQ=,tag:kkXAdX+iIlFcBpIHTpDxPw==,type:str]
+    username: ENC[AES256_GCM,data:h6bq,iv:0c/I+ULLzSJ4pUtsdOAV2sUiT545Ct2RAylymwHI+PU=,tag:M8W8Z8881AiCAsKOT4UzpQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -15,14 +15,14 @@ sops:
         - recipient: age1y0deq3t66yld72t4p8eawngpreffrsvztaffhj7f3wccercdx4psy5mvl7
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIMzQ5Sk1jT2d2TFU3TmtT
-            NWttMlhzekhqSk0waUNQc1JNb1ZraE5KZkZBCnU0VkkwUXVyRFlpSVpzL2dUWWwx
-            WXh2VEFnNkhoODk4V1ZxVDVlVzVDcmMKLS0tIFRDZ2EzSlkyMUdXRFU2c3ZwKzdX
-            eDc0ZEFEc3YwK1B2NVNVN2pwcEVxSXMKLD7W0FgynJMY1yJxA8ssVtQr7KG3cPLS
-            DGjHydwTNkS/u0FHaiwy6x7ub3AgO6H3I/NcVm4JkTJStbnraKtwMw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1MStaRjV0RGUrNU5BSWhD
+            OEZDTmxSU0JDTTRaY3IwbGw0TW1EWlVzMERZClJhTEdIZ01ieEJuQ1VkOVp2dHRa
+            V1R2YkxvNmVMbThLSk15eFQ2SzZTb0UKLS0tIHpHY1lsUDRrZkowWmdaMzdmQklT
+            YWl0aCsyVkpORGFsS2JrYjVhUTZ2UFEKv0PUtKIdu+16MIVFsdBtJ8JV0Ua7MY5N
+            7Yy1I9rHEcR8B4QO7/7wo5JgrGVZz15h7gnx4ZU9OHynaBCE6D38UA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-06-13T19:25:30Z"
-    mac: ENC[AES256_GCM,data:LbjefONOPoVQ0ovXaHEnX6EhjJ6pSJWcDVdyvhQicSzMueYO8wNxmWwUhYARwQi3tsEsHAJoZjow9vJA0MoRVI9F5HbjBSa9gTpsjEIuNAfKCYVO2QhkGDfOkIj7MQM30kBOi8wkp7hyGYLrQTkri/wtrWybfPxQ1oRrvqn/Z7E=,iv:eDuGBCPkrSDG5hitcqFgjCtzKrUSwOsFeEVzm3jdROk=,tag:m/WS40AhLWBZATH5MFT5FA==,type:str]
+    lastmodified: "2024-06-13T20:06:38Z"
+    mac: ENC[AES256_GCM,data:WVZ4UFFt+GNLJcBTfaIo5PjIFeR/9e/37jTKgS/tkdP0oBtAp+MhJSU7MKddYy9SYKeCEon84Q/r1uy/6IZYDXFv/+u1T6OMD8uzTTlqascVGdaO4duMbw341lMW8lgigQYxEpvqJZxmPaJGQVl0gqREpTIBqJcTex8iE7U537M=,iv:CWpMafRbKqcNhyMPRz55m5cbSHCXlTloxbCAl100Az0=,tag:kNmgfbkOSwFV75fenDvpCw==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1


### PR DESCRIPTION
# Description

tad can not use secrets that contain special url characters (we need to also fix that in tad). For now do not use those characters

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [x]  I have squashed or reorganized my commits into logical units.
- [x]  I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
