### PR TITLE
Add env vars for minio service

### DIFF
--- a/apps/amt/base/deployment-minio.yaml
+++ b/apps/amt/base/deployment-minio.yaml
@@ -31,12 +31,16 @@ spec:
             memory: 512Mi
             ephemeral-storage: "2Gi"
         env:
-        - name: MINIO_ROOT_PASSWORD
+        - name: OBJECT_STORE_URL
+          value: amt-svc-minio:9000
+        - name: OBJECT_STORE_BUCKET_NAME
+          value: amt
+        - name: OBJECT_STORE_PASSWORD
           valueFrom:
             secretKeyRef:
               name: sec-minio
               key: minio_root_password
-        - name: MINIO_ROOT_USER
+        - name: OBJECT_STORE_USER
           valueFrom:
             secretKeyRef:
               name: sec-minio


### PR DESCRIPTION
# Description

Sets env vars to be used by AMT to connect to the minio object storage service.


## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [x]  I have squashed or reorganized my commits into logical units.
- [x]  I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
