### PR TITLE
Pin action-mattermost-notify to SHA instead of @master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
           echo "product=$PRODUCT" >> $GITHUB_OUTPUT
         id: changed_files
 
-      - uses: mattermost/action-mattermost-notify@master
+      - uses: mattermost/action-mattermost-notify@d317daebed2a792679f68fd0248557a8d21d82b6
         if: github.event_name != 'pull_request' && contains(needs.*.result, 'failure')
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MM_WEBHOOK_URL }}
@@ -164,7 +164,7 @@ jobs:
           MATTERMOST_USERNAME: ${{ github.triggering_actor }}
 
 
-      - uses: mattermost/action-mattermost-notify@master
+      - uses: mattermost/action-mattermost-notify@d317daebed2a792679f68fd0248557a8d21d82b6
         if: github.event_name != 'pull_request' && ! contains(needs.*.result, 'failure')
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MM_WEBHOOK_URL }}


### PR DESCRIPTION
Automated migration by stuc.

---
Part of campaign: https://github.com/RijksICTGilde/stuc-campaigns/issues/3
Managed by [stuc](https://github.com/RijksICTGilde/stuc)